### PR TITLE
Rework FindIntro logic per redundant strategy

### DIFF
--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -539,8 +539,7 @@ namespace llarp
     void
     Context::LookupIntroSetForPath(const Key_t& addr, uint64_t txid,
                                    const llarp::PathID_t& path,
-                                   const Key_t& askpeer,
-                                   uint64_t relayOrder)
+                                   const Key_t& askpeer, uint64_t relayOrder)
     {
       TXOwner asker(OurKey(), txid);
       TXOwner peer(askpeer, ++ids);

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -45,16 +45,14 @@ namespace llarp
         GetRouter()->rcLookupHandler().CheckRC(rc);
       }
 
-      /// on behalf of whoasked request introset for target from dht router with
-      /// key askpeer
       void
-      LookupIntroSetRecursive(
+      LookupIntroSetRelayed(
           const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
-          const Key_t& askpeer, uint64_t recursionDepth, uint64_t relayOrder,
+          const Key_t& askpeer, uint64_t relayOrder,
           service::EncryptedIntroSetLookupHandler result = nullptr) override;
 
       void
-      LookupIntroSetIterative(
+      LookupIntroSetDirect(
           const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
           const Key_t& askpeer,
           service::EncryptedIntroSetLookupHandler result = nullptr) override;
@@ -94,7 +92,6 @@ namespace llarp
       void
       LookupIntroSetForPath(const Key_t& addr, uint64_t txid,
                             const llarp::PathID_t& path, const Key_t& askpeer,
-                            uint64_t recursionDepth,
                             uint64_t relayOrder) override;
 
       /// send a dht message to peer, if keepalive is true then keep the session
@@ -543,15 +540,14 @@ namespace llarp
     Context::LookupIntroSetForPath(const Key_t& addr, uint64_t txid,
                                    const llarp::PathID_t& path,
                                    const Key_t& askpeer,
-                                   uint64_t recursionDepth, uint64_t relayOrder)
+                                   uint64_t relayOrder)
     {
       TXOwner asker(OurKey(), txid);
       TXOwner peer(askpeer, ++ids);
       _pendingIntrosetLookups.NewTX(
           peer, asker, addr,
           new LocalServiceAddressLookup(path, txid, relayOrder, addr, this,
-                                        askpeer),
-          ((recursionDepth + 1) * 2000));
+                                        askpeer));
     }
 
     void
@@ -569,18 +565,16 @@ namespace llarp
     }
 
     void
-    Context::LookupIntroSetRecursive(
+    Context::LookupIntroSetRelayed(
         const Key_t& addr, const Key_t& whoasked, uint64_t txid,
-        const Key_t& askpeer, uint64_t recursionDepth, uint64_t relayOrder,
+        const Key_t& askpeer, uint64_t relayOrder,
         service::EncryptedIntroSetLookupHandler handler)
     {
       TXOwner asker(whoasked, txid);
       TXOwner peer(askpeer, ++ids);
       _pendingIntrosetLookups.NewTX(
           peer, asker, addr,
-          new ServiceAddressLookup(asker, addr, this, recursionDepth,
-                                   relayOrder, handler),
-          ((recursionDepth + 1) * 2000));
+          new ServiceAddressLookup(asker, addr, this, relayOrder, handler));
     }
 
     void
@@ -594,7 +588,7 @@ namespace llarp
     }
 
     void
-    Context::LookupIntroSetIterative(
+    Context::LookupIntroSetDirect(
         const Key_t& addr, const Key_t& whoasked, uint64_t txid,
         const Key_t& askpeer, service::EncryptedIntroSetLookupHandler handler)
     {
@@ -602,7 +596,7 @@ namespace llarp
       TXOwner peer(askpeer, ++ids);
       _pendingIntrosetLookups.NewTX(
           peer, asker, addr,
-          new ServiceAddressLookup(asker, addr, this, 0, 0, handler), 1000);
+          new ServiceAddressLookup(asker, addr, this, 0, handler), 1000);
     }
 
     bool

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -42,17 +42,17 @@ namespace llarp
                             uint64_t whoaskedTX, const Key_t& askpeer,
                             RouterLookupHandler result = nullptr) = 0;
 
-      /// on behalf of whoasked request introset for target from dht router with
-      /// key askpeer
+      /// Ask a Service Node to perform an Introset lookup for us
       virtual void
-      LookupIntroSetRecursive(
+      LookupIntroSetRelayed(
           const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
-          const Key_t& askpeer, uint64_t recursionDepth, uint64_t relayOrder,
+          const Key_t& askpeer, uint64_t relayOrder,
           service::EncryptedIntroSetLookupHandler result =
               service::EncryptedIntroSetLookupHandler()) = 0;
 
+      /// Directly as a Service Node for an Introset
       virtual void
-      LookupIntroSetIterative(
+      LookupIntroSetDirect(
           const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
           const Key_t& askpeer,
           service::EncryptedIntroSetLookupHandler result =
@@ -69,7 +69,7 @@ namespace llarp
       virtual void
       LookupIntroSetForPath(const Key_t& addr, uint64_t txid,
                             const PathID_t& path, const Key_t& askpeer,
-                            uint64_t recursionDepth, uint64_t relayOrder) = 0;
+                            uint64_t relayOrder) = 0;
 
       virtual void
       DHTSendTo(const RouterID& peer, IMessage* msg, bool keepalive = true) = 0;

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -44,19 +44,18 @@ namespace llarp
 
       /// Ask a Service Node to perform an Introset lookup for us
       virtual void
-      LookupIntroSetRelayed(
-          const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
-          const Key_t& askpeer, uint64_t relayOrder,
-          service::EncryptedIntroSetLookupHandler result =
-              service::EncryptedIntroSetLookupHandler()) = 0;
+      LookupIntroSetRelayed(const Key_t& target, const Key_t& whoasked,
+                            uint64_t whoaskedTX, const Key_t& askpeer,
+                            uint64_t relayOrder,
+                            service::EncryptedIntroSetLookupHandler result =
+                                service::EncryptedIntroSetLookupHandler()) = 0;
 
       /// Directly as a Service Node for an Introset
       virtual void
-      LookupIntroSetDirect(
-          const Key_t& target, const Key_t& whoasked, uint64_t whoaskedTX,
-          const Key_t& askpeer,
-          service::EncryptedIntroSetLookupHandler result =
-              service::EncryptedIntroSetLookupHandler()) = 0;
+      LookupIntroSetDirect(const Key_t& target, const Key_t& whoasked,
+                           uint64_t whoaskedTX, const Key_t& askpeer,
+                           service::EncryptedIntroSetLookupHandler result =
+                               service::EncryptedIntroSetLookupHandler()) = 0;
 
       virtual bool
       HasRouterLookup(const RouterID& target) const = 0;

--- a/llarp/dht/localserviceaddresslookup.cpp
+++ b/llarp/dht/localserviceaddresslookup.cpp
@@ -15,7 +15,7 @@ namespace llarp
         const PathID_t &pathid, uint64_t txid, uint64_t relayOrder,
         const Key_t &addr, AbstractContext *ctx,
         __attribute__((unused)) const Key_t &askpeer)
-        : ServiceAddressLookup(TXOwner{ctx->OurKey(), txid}, addr, ctx, 2,
+        : ServiceAddressLookup(TXOwner{ctx->OurKey(), txid}, addr, ctx, 
                                relayOrder, nullptr)
         , localPath(pathid)
     {

--- a/llarp/dht/localserviceaddresslookup.cpp
+++ b/llarp/dht/localserviceaddresslookup.cpp
@@ -15,7 +15,7 @@ namespace llarp
         const PathID_t &pathid, uint64_t txid, uint64_t relayOrder,
         const Key_t &addr, AbstractContext *ctx,
         __attribute__((unused)) const Key_t &askpeer)
-        : ServiceAddressLookup(TXOwner{ctx->OurKey(), txid}, addr, ctx, 
+        : ServiceAddressLookup(TXOwner{ctx->OurKey(), txid}, addr, ctx,
                                relayOrder, nullptr)
         , localPath(pathid)
     {

--- a/llarp/dht/messages/findintro.cpp
+++ b/llarp/dht/messages/findintro.cpp
@@ -9,7 +9,7 @@ namespace llarp
 {
   namespace dht
   {
-    FindIntroMessage::~FindIntroMessage()              = default;
+    FindIntroMessage::~FindIntroMessage() = default;
 
     bool
     FindIntroMessage::DecodeKey(const llarp_buffer_t& k, llarp_buffer_t* val)

--- a/llarp/dht/messages/findintro.hpp
+++ b/llarp/dht/messages/findintro.hpp
@@ -12,8 +12,6 @@ namespace llarp
   {
     struct FindIntroMessage final : public IMessage
     {
-      static const uint64_t MaxRecursionDepth;
-      uint64_t recursionDepth = 0;
       Key_t location;
       llarp::service::Tag tagName;
       uint64_t txID       = 0;
@@ -27,20 +25,14 @@ namespace llarp
         relayOrder = order;
       }
 
-      FindIntroMessage(const llarp::service::Tag& tag, uint64_t txid,
-                       bool iterate = true)
+      FindIntroMessage(const llarp::service::Tag& tag, uint64_t txid)
           : IMessage({}), tagName(tag), txID(txid)
       {
-        if(iterate)
-          recursionDepth = 0;
-        else
-          recursionDepth = 1;
       }
 
       explicit FindIntroMessage(uint64_t txid, const Key_t& addr,
-                                uint64_t maxRecursionDepth, uint64_t order)
+                                uint64_t order)
           : IMessage({})
-          , recursionDepth(maxRecursionDepth)
           , location(addr)
           , txID(txid)
           , relayOrder(order)

--- a/llarp/dht/messages/findintro.hpp
+++ b/llarp/dht/messages/findintro.hpp
@@ -32,10 +32,7 @@ namespace llarp
 
       explicit FindIntroMessage(uint64_t txid, const Key_t& addr,
                                 uint64_t order)
-          : IMessage({})
-          , location(addr)
-          , txID(txid)
-          , relayOrder(order)
+          : IMessage({}), location(addr), txID(txid), relayOrder(order)
       {
         tagName.Zero();
       }

--- a/llarp/dht/serviceaddresslookup.cpp
+++ b/llarp/dht/serviceaddresslookup.cpp
@@ -52,9 +52,8 @@ namespace llarp
     void
     ServiceAddressLookup::Start(const TXOwner &peer)
     {
-      parent->DHTSendTo(
-          peer.node.as_array(),
-          new FindIntroMessage(peer.txid, target, relayOrder));
+      parent->DHTSendTo(peer.node.as_array(),
+                        new FindIntroMessage(peer.txid, target, relayOrder));
     }
 
     void

--- a/llarp/dht/serviceaddresslookup.cpp
+++ b/llarp/dht/serviceaddresslookup.cpp
@@ -11,11 +11,9 @@ namespace llarp
   {
     ServiceAddressLookup::ServiceAddressLookup(
         const TXOwner &asker, const Key_t &addr, AbstractContext *ctx,
-        uint64_t recursion, uint32_t order,
-        service::EncryptedIntroSetLookupHandler handler)
+        uint32_t order, service::EncryptedIntroSetLookupHandler handler)
         : TX< Key_t, service::EncryptedIntroSet >(asker, addr, ctx)
         , handleResult(std::move(handler))
-        , recursionDepth(recursion)
         , relayOrder(order)
     {
       peersAsked.insert(ctx->OurKey());
@@ -56,22 +54,14 @@ namespace llarp
     {
       parent->DHTSendTo(
           peer.node.as_array(),
-          new FindIntroMessage(peer.txid, target, recursionDepth, relayOrder));
+          new FindIntroMessage(peer.txid, target, relayOrder));
     }
 
     void
     ServiceAddressLookup::DoNextRequest(const Key_t &ask)
     {
-      if(recursionDepth)
-      {
-        parent->LookupIntroSetRecursive(target, whoasked.node, whoasked.txid,
-                                        ask, recursionDepth - 1, relayOrder);
-      }
-      else
-      {
-        parent->LookupIntroSetIterative(target, whoasked.node, whoasked.txid,
-                                        ask);
-      }
+      (void)ask;
+      // do nothing -- we handle propagating this explicitly
     }
 
     void

--- a/llarp/dht/serviceaddresslookup.hpp
+++ b/llarp/dht/serviceaddresslookup.hpp
@@ -15,12 +15,10 @@ namespace llarp
     struct ServiceAddressLookup : public TX< Key_t, service::EncryptedIntroSet >
     {
       service::EncryptedIntroSetLookupHandler handleResult;
-      uint64_t recursionDepth;
       uint32_t relayOrder;
 
       ServiceAddressLookup(const TXOwner &asker, const Key_t &addr,
-                           AbstractContext *ctx, uint64_t recursionDepth,
-                           uint32_t relayOrder,
+                           AbstractContext *ctx, uint32_t relayOrder,
                            service::EncryptedIntroSetLookupHandler handler);
 
       bool

--- a/llarp/dht/taglookup.cpp
+++ b/llarp/dht/taglookup.cpp
@@ -28,9 +28,8 @@ namespace llarp
     void
     TagLookup::Start(const TXOwner &peer)
     {
-      parent->DHTSendTo(
-          peer.node.as_array(),
-          new FindIntroMessage(target, peer.txid));
+      parent->DHTSendTo(peer.node.as_array(),
+                        new FindIntroMessage(target, peer.txid));
     }
 
     void

--- a/llarp/dht/taglookup.cpp
+++ b/llarp/dht/taglookup.cpp
@@ -30,7 +30,7 @@ namespace llarp
     {
       parent->DHTSendTo(
           peer.node.as_array(),
-          new FindIntroMessage(target, peer.txid, recursionDepth));
+          new FindIntroMessage(target, peer.txid));
     }
 
     void

--- a/llarp/service/hidden_service_address_lookup.cpp
+++ b/llarp/service/hidden_service_address_lookup.cpp
@@ -46,7 +46,7 @@ namespace llarp
     {
       auto msg = std::make_shared< routing::DHTMessage >();
       msg->M.emplace_back(std::make_unique< dht::FindIntroMessage >(
-          txid, location, 2, relayOrder));
+          txid, location, relayOrder));
       return msg;
     }
 

--- a/test/dht/mock_context.hpp
+++ b/test/dht/mock_context.hpp
@@ -19,12 +19,12 @@ namespace llarp
                    void(const RouterID&, const dht::Key_t&, uint64_t,
                         const dht::Key_t&, RouterLookupHandler));
 
-      MOCK_METHOD7(LookupIntroSetRecursive,
+      MOCK_METHOD6(LookupIntroSetRelayed,
                    void(const dht::Key_t&, const dht::Key_t&, uint64_t,
-                        const dht::Key_t&, uint64_t, uint64_t,
+                        const dht::Key_t&, uint64_t,
                         service::EncryptedIntroSetLookupHandler));
 
-      MOCK_METHOD5(LookupIntroSetIterative,
+      MOCK_METHOD5(LookupIntroSetDirect,
                    void(const dht::Key_t&, const dht::Key_t&, uint64_t,
                         const dht::Key_t&,
                         service::EncryptedIntroSetLookupHandler));
@@ -35,9 +35,9 @@ namespace llarp
                    void(const RouterID& target, uint64_t txid,
                         const PathID_t& path, const dht::Key_t& askpeer));
 
-      MOCK_METHOD6(LookupIntroSetForPath,
+      MOCK_METHOD5(LookupIntroSetForPath,
                    void(const dht::Key_t&, uint64_t, const PathID_t&,
-                        const dht::Key_t&, uint64_t, uint64_t));
+                        const dht::Key_t&, uint64_t));
 
       MOCK_METHOD3(DHTSendTo, void(const RouterID&, dht::IMessage*, bool));
 


### PR DESCRIPTION
This attempts to rework the remaining DHT lookup logic to conform to our "redundant DHT strategy." 

One very concrete issue this addresses is that a node handling a relayed lookup will not attempt to return a matching entry if it happens to have it.

TODO: I don't think this handles the case where (1) lookup is relayed and (2) we are the target owner (i.e. we are in the set {A..D})